### PR TITLE
feat: http logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.ua-parser</groupId>
+			<artifactId>uap-java</artifactId>
+			<version>1.6.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/project/management/config/ApplicationConfig.java
+++ b/src/main/java/com/example/project/management/config/ApplicationConfig.java
@@ -1,0 +1,15 @@
+package com.example.project.management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import ua_parser.Parser;
+
+@Configuration
+public class ApplicationConfig {
+
+    @Bean
+    public Parser getParser() {
+        return new Parser();
+    }
+
+}

--- a/src/main/java/com/example/project/management/controllers/DemoController.java
+++ b/src/main/java/com/example/project/management/controllers/DemoController.java
@@ -1,0 +1,16 @@
+package com.example.project.management.controllers;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/v1/demo")
+@RestController
+public class DemoController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "pong";
+    }
+
+}

--- a/src/main/java/com/example/project/management/interceptor/InterceptorConfiguration.java
+++ b/src/main/java/com/example/project/management/interceptor/InterceptorConfiguration.java
@@ -1,0 +1,20 @@
+package com.example.project.management.interceptor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class InterceptorConfiguration implements WebMvcConfigurer {
+
+    private final HandlerInterceptor handlerInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(handlerInterceptor);
+    }
+
+}

--- a/src/main/java/com/example/project/management/interceptor/LogInterceptor.java
+++ b/src/main/java/com/example/project/management/interceptor/LogInterceptor.java
@@ -1,0 +1,47 @@
+package com.example.project.management.interceptor;
+
+import com.example.project.management.model.Log;
+import com.example.project.management.model.LogRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import ua_parser.Parser;
+
+@Component
+@RequiredArgsConstructor
+public class LogInterceptor implements HandlerInterceptor {
+
+    private final Parser parser;
+    private final LogRepository logRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(LogInterceptor.class);
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) {
+
+        final var userAgentHeader = request.getHeader("user-agent");
+        final var client = parser.parse(userAgentHeader);
+
+        logRepository.save(
+                new Log(
+                        request.getMethod(),
+                        request.getRequestURI(),
+                        client.userAgent.family,
+                        client.os.family,
+                        client.device.family
+                )
+        );
+
+        logger.info("Saved new log from log interceptor");
+
+        return true;
+    }
+}

--- a/src/main/java/com/example/project/management/model/Log.java
+++ b/src/main/java/com/example/project/management/model/Log.java
@@ -1,0 +1,27 @@
+package com.example.project.management.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Log {
+
+    @Id
+    private final UUID id = UUID.randomUUID();
+    private final LocalDateTime issuedAt = LocalDateTime.now();
+    private String httpMethod;
+    private String requestURI;
+    private String browser;
+    private String OS;
+    private String device;
+
+}

--- a/src/main/java/com/example/project/management/model/LogRepository.java
+++ b/src/main/java/com/example/project/management/model/LogRepository.java
@@ -1,0 +1,7 @@
+package com.example.project.management.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface LogRepository extends JpaRepository<Log, UUID> {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=project.management
+
+spring.datasource.url=jdbc:mysql://localhost:3306/taller
+spring.datasource.username=root
+spring.datasource.password=password
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/example/project/management/interceptor/LogInterceptorSpyTest.java
+++ b/src/test/java/com/example/project/management/interceptor/LogInterceptorSpyTest.java
@@ -1,0 +1,40 @@
+package com.example.project.management.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LogInterceptorSpyTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LogInterceptor logInterceptor;
+
+    @Test
+    void testPostHandleIsCalled() throws Exception {
+        mockMvc.perform(get("/v1/demo/ping")
+                        .header("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"))
+                .andExpect(status().isOk());
+
+        verify(logInterceptor, times(1)).preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any(Object.class)
+        );
+    }
+}

--- a/src/test/java/com/example/project/management/interceptor/LogInterceptorTest.java
+++ b/src/test/java/com/example/project/management/interceptor/LogInterceptorTest.java
@@ -1,0 +1,47 @@
+package com.example.project.management.interceptor;
+
+import com.example.project.management.model.LogRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class LogInterceptorTest {
+
+    @Autowired
+    private LogInterceptor logInterceptor;
+
+    @MockBean
+    private LogRepository logRepository;
+
+    @MockBean
+    private HttpServletRequest request;
+
+    @MockBean
+    private HttpServletResponse response;
+
+    @Test
+    void testPostHandle() {
+        when(request.getHeader("user-agent"))
+                .thenReturn("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36, acceptLanguage:en-US,en;q=0.9");
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestURI()).thenReturn("/v1/test");
+
+        logInterceptor.preHandle(request, response, new Object());
+
+        verify(logRepository).save(argThat(log ->
+                log.getHttpMethod().equals("GET") &&
+                        log.getRequestURI().equals("/v1/test") &&
+                        log.getBrowser().equals("Chrome") &&
+                        log.getOS().equals("Mac OS X") &&
+                        log.getDevice().equals("Mac")
+        ));
+    }
+}


### PR DESCRIPTION
Se implementó una funcionalidad para registrar **logs** en la base de datos. Por _log_ se entiende cada registro que nos brinda información acerca de las requests que se realizan a nuestra aplicación.

## Funcionamiento

El interceptor se configuró como implementación de la interfaz HandlerInterceptor. Los objetos de este tipo pueden actuar antes de que llegue la request al despachador (a través del _preHandle_) o después de procesada la request (a través de un _postHandle_). En este caso, decidí aplicar el primer enfoque.

A través de estos métodos, es posible acceder a la request HTTP y obtener información de ella. En este caso, se extrae y se lee el encabezado **user agent**, que contiene información acerca del cliente que realizó la request.

Con ello, todas las requests serán registradas en la base de datos, guardando la URI del recurso que se solicitó y el dispositivo y el browser desde el cual se realizó la request.

## Tests

Se realizaron **dos tests de integración** para verificar el funcionamiento. Un test para comprobar el funcionamiento del interceptor como tal y otro test para verificar que, si se hace una request a cualquier endpoint, el interceptor verdaderamente actúe.